### PR TITLE
feat(order): agrego endpoint para numero de seguimiento de confirmaci…

### DIFF
--- a/apps/rappi-backend-m2/src/order/presentation/controllers/order.controller.ts
+++ b/apps/rappi-backend-m2/src/order/presentation/controllers/order.controller.ts
@@ -5,6 +5,7 @@ import { GetOrderResponseDto } from '../dtos/get-order-response.dto';
 import { GetUserOrdersResponseDto } from '../dtos/get-orders-response.dto';
 import { UpdateOrderStatusRequestDto } from '../dtos/update-status.dto';
 import { SummaryDto } from '../dtos/order-dto-response/summary.dto';
+import { OrderStatus } from '../../domain/enum/order-status';
 
 @Controller('orders')
 export class OrderController {
@@ -41,5 +42,9 @@ export class OrderController {
     return { message: 'Estado actualizado correctamente' };
   }
 
+  @Put(':id/confirm')
+  async confirmOrder(@Param('id') id: string): Promise<GetOrderResponseDto> {
+    return this.orderService.confirmOrder(id);
+  }
    
 }

--- a/apps/rappi-backend-m2/src/order/services/order.service.ts
+++ b/apps/rappi-backend-m2/src/order/services/order.service.ts
@@ -243,6 +243,19 @@ export class OrderService {
     return SummaryDto.fromEntity(orderEntity.getSummary());
   }
   
+  async confirmOrder(orderId: string): Promise<GetOrderResponseDto> {
+    const order = await this.orderRepository.findById(orderId);
+    if (!order) throw new BadRequestException(`Orden con id ${orderId} no encontrada`);
+
+    if (order.getStatus() !== OrderStatus.Pending) {
+      throw new BadRequestException(`Solo se puede confirmar una orden en estado 'pending'. Estado actual: '${order.getStatus()}'`);
+    }
+
+    await this.UpdateOrderStatus(orderId, OrderStatus.Accepted);
+
+    const updated = await this.orderRepository.findById(orderId);
+    return GetOrderResponseDto.fromEntity(updated!);
+  }
 }
 
 


### PR DESCRIPTION
e precisa confirmar órdenes pendientes, cambiando su estado a accepted y retornando el trackingNumber previamente guardado. No se generan automáticamente tracking numbers.
Cambios:
- OrderController : nuevo endpoint PUT /api/orders/:id/confirm .
- OrderService.confirmOrder : valida pending , actualiza estado con UpdateOrderStatus , y retorna la orden actualizada (incluye trackingNumber ).