### PR TITLE
feat(order): WhatsApp link en confirmación con fecha y detalles de pago

### DIFF
--- a/apps/rappi-backend-m2/src/order/infrastructure/repositories/order.repository.ts
+++ b/apps/rappi-backend-m2/src/order/infrastructure/repositories/order.repository.ts
@@ -22,7 +22,7 @@ interface PopulatedUser {
 
 
 @Injectable()
-export class OrderRepository implements IOrderRepository{
+export class OrderRepository implements IOrderRepository {
     constructor(
         @InjectModel(Order.name) private orderModel : Model<OrderDocument>
     ){}
@@ -122,8 +122,18 @@ export class OrderRepository implements IOrderRepository{
       }
   }
 
-  
+  async confirm(orderId: string, trackingNumber: string): Promise<void> {
+    if(!Types.ObjectId.isValid(orderId)) throw new BadRequestException('Id no válido');
+    const result = await this.orderModel.updateOne(
+      { _id: orderId },
+      { $set: { status: OrderStatus.Accepted, trackingNumber } }
+    );
 
+    if (result.matchedCount === 0) {
+      throw new BadRequestException('Orden no encontrada');
+    }
+  }
+  
   private mapUser(user: Types.ObjectId | PopulatedUser | null | undefined): UserBasicEntity | undefined {;
       if (!user || typeof user === 'string') return undefined;
       const populated = user as PopulatedUser;

--- a/apps/rappi-backend-m2/src/order/presentation/controllers/order.controller.ts
+++ b/apps/rappi-backend-m2/src/order/presentation/controllers/order.controller.ts
@@ -6,6 +6,7 @@ import { GetUserOrdersResponseDto } from '../dtos/get-orders-response.dto';
 import { UpdateOrderStatusRequestDto } from '../dtos/update-status.dto';
 import { SummaryDto } from '../dtos/order-dto-response/summary.dto';
 import { OrderStatus } from '../../domain/enum/order-status';
+import { ConfirmOrderResponseDto } from '../dtos/confirm-order-response.dto';
 
 @Controller('orders')
 export class OrderController {
@@ -43,8 +44,14 @@ export class OrderController {
   }
 
   @Put(':id/confirm')
-  async confirmOrder(@Param('id') id: string): Promise<GetOrderResponseDto> {
-    return this.orderService.confirmOrder(id);
+  async confirmOrder(@Param('id') id: string, @Query('phone') phone?: string): Promise<ConfirmOrderResponseDto> {
+    const order = await this.orderService.confirmOrder(id);
+    let whatsappLink = '';
+    if (phone) {
+      const { url } = await this.orderService.getWhatsAppLink(id, phone);
+      whatsappLink = url;
+    }
+    return ConfirmOrderResponseDto.of(order, whatsappLink);
   }
    
 }

--- a/apps/rappi-backend-m2/src/order/presentation/dtos/confirm-order-response.dto.ts
+++ b/apps/rappi-backend-m2/src/order/presentation/dtos/confirm-order-response.dto.ts
@@ -1,0 +1,20 @@
+import { GetOrderResponseDto } from './get-order-response.dto';
+
+export class ConfirmOrderResponseDto {
+  constructor(
+    private readonly _order: GetOrderResponseDto,
+    private readonly _whatsappLink: string
+  ) {}
+
+  get order(): GetOrderResponseDto {
+    return this._order;
+  }
+
+  get whatsappLink(): string {
+    return this._whatsappLink;
+  }
+
+  static of(order: GetOrderResponseDto, whatsappLink: string): ConfirmOrderResponseDto {
+    return new ConfirmOrderResponseDto(order, whatsappLink);
+  }
+}

--- a/apps/rappi-backend-m2/src/order/services/order.service.ts
+++ b/apps/rappi-backend-m2/src/order/services/order.service.ts
@@ -256,6 +256,52 @@ export class OrderService {
     const updated = await this.orderRepository.findById(orderId);
     return GetOrderResponseDto.fromEntity(updated!);
   }
+  
+  async getWhatsAppLink(orderId: string, phoneRaw: string): Promise<{ url: string }> {
+    const order = await this.orderRepository.findById(orderId);
+    if (!order) throw new BadRequestException(`Orden con id ${orderId} no encontrada`);
+
+    const phone = (phoneRaw || '').replace(/[^0-9]/g, '');
+    if (!phone) throw new BadRequestException('Número de teléfono inválido');
+
+    const vendorName = order.getVendor()?.getName() ?? 'Desconocido';
+    const customerName = order.getCustomer()?.getName() ?? 'Desconocido';
+
+    const itemsText = order.getItems()
+      .map(i => `${i.getQuantity()} x ${i.getName()} (${new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(i.getPrice())})`)
+      .join(', ');
+
+    const totalFmt = new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(order.getSummary().getTotal());
+    const tracking = order.getTrackingNumber();
+    const orderIdText = order.getId().toString();
+
+    const createdAt = order.getCreatedAt();
+    const whenLocal = createdAt.toLocaleString('es-AR', { dateStyle: 'short', timeStyle: 'short' });
+
+    const delivery = order.getDeliveryLocation();
+    const deliveryCoords = `(${delivery.getLatitude()}, ${delivery.getLongitude()})`;
+
+    const pay = order.getPayment();
+    const methodPretty = (pay?.getMethod() ?? '-').toLowerCase().replace(/^\w/, c => c.toUpperCase());
+    const statusPretty = (pay?.getStatus() ?? '-').toLowerCase().replace(/^\w/, c => c.toUpperCase());
+    const tx = pay?.getTransactionId();
+    const paymentLine = `Pago: ${methodPretty} • Estado: ${statusPretty}${tx ? ` • TX: ${tx}` : ''}`;
+
+    const message =
+      `Hola! Quiero confirmar mi pedido.\n` +
+      `Pedido: ${orderIdText}\n` +
+      `Fecha: ${whenLocal}\n` +
+      `Cliente: ${customerName}\n` +
+      `Vendor: ${vendorName}\n` +
+      `Entrega: ${deliveryCoords}\n` +
+      `Items: ${itemsText}\n` +
+      `Total: ${totalFmt}\n` +
+      `${paymentLine}\n` +
+      `Tracking: ${tracking}`;
+
+    const url = `https://wa.me/${phone}?text=${encodeURIComponent(message)}`;
+    return { url };
+  }
 }
 
 


### PR DESCRIPTION
Resumen

- Integra el whatsappLink directamente en la respuesta del endpoint de confirmación de orden ( PUT /api/orders/:id/confirm ), permitiendo redirigir al cliente a WhatsApp con un mensaje preformateado.
- El mensaje incluye fecha y hora legibles, datos del cliente y comercio, coordenadas de entrega, items con precios, total formateado en ARS, medio y estado de pago, transactionId opcional y número de seguimiento.
- tambien subo un cambio de la hu de ayer porque no lo habia guardado y no llegue a subir el cambio en la pr anterior